### PR TITLE
remove enforcement of using subject

### DIFF
--- a/eng/rails/test.md
+++ b/eng/rails/test.md
@@ -192,15 +192,6 @@ We can separate steps into files using standard type. We can separate each featu
     before(:each) {@article = FactoryGirl.create :article}
   ```
 
-* Must use `expect` or `is_expected` with `subject`.
-
-  ```ruby
-    describe Article do
-      subject {FactoryGirl.create :article}
-      it {is_expected.to be_published}
-    end
-  ```
-
 * Inside `it` we can use `expect` and `is_expected`. Do not use `specify` or `should`.
 * Do not use strings to be parameters of `it`. Write spec self explanatory.
 


### PR DESCRIPTION
In the current coding convention for RSpec, it enforces us to use `subject` in every test. _I would like to propose to remove the restriction._
The purpose of that convention is unifying the way to write RSpec codes among developers in Framgia. On the other hand, RSpec codes we write sometimes can be lengthy due to the convention. If we can go without it, the test codes would be simpler. In my opinion, to be able to write simpler is prior to the strict explicitness of the subject.
BTW [Better Specs](http://betterspecs.org/#subject) which is based on our convention says that `If you have several tests related to the same subject use subject{} to DRY them up.`.

What do you think about this? Any comment from anybody is welcome.

``` ruby
# Current way can clarify the subject, but it can make the code lengthy.
describe Article do
  subject {FactoryGirl.create :article}
  it {is_expected.to be_an Article}
end

describe Article do
  let!(:article){FactoryGirl.create :article}
  subject {->{article.destroy}}
  it {is_expected.to change(Article.count).by(-1)}
end
```

``` ruby
# In the proposed way.
# More straight-ward and readable way
describe Article do
  let(:article){FactoryGirl.create :article}
  it {expect(article).to be_an Article}
end

describe Article do
  let!(:article){FactoryGirl.create :article}
  it {expect{article.destroy}.to change(Article.count).by(-1)}
end
```

``` ruby
# Also in the proposed way.
# Among multiple tests for the same subject
describe Article do
  let(:article){FactoryGirl.create :article}
  subject {article}
  it {is_expected.to be_an Article}
  it {is_expected.to be_an Attachable}
  it {is_expected.to be_an ActiveRecord::Base}
end
```
